### PR TITLE
Connection pool improvements

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Connection.cs
@@ -94,6 +94,11 @@ namespace Gremlin.Net.Driver
             return false;
         }
 
+        public int DecrementBorrowed()
+        {
+            return Interlocked.Decrement(ref _nrBorrowed);
+        }
+
         public int NrRequestsInFlight => _callbackByRequestId.Count;
 
         public bool IsOpen => _webSocketConnection.IsOpen;

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionFactory.cs
@@ -24,6 +24,8 @@
 using System;
 using System.Net.WebSockets;
 using Gremlin.Net.Structure.IO.GraphSON;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Gremlin.Net.Driver
 {
@@ -32,12 +34,14 @@ namespace Gremlin.Net.Driver
         private readonly GraphSONReader _graphSONReader;
         private readonly GraphSONWriter _graphSONWriter;
         private readonly Action<ClientWebSocketOptions> _webSocketConfiguration;
+        private readonly ILogger _logger;
         private readonly GremlinServer _gremlinServer;
         private readonly string _mimeType;
 
         public ConnectionFactory(GremlinServer gremlinServer, GraphSONReader graphSONReader,
-            GraphSONWriter graphSONWriter, string mimeType, Action<ClientWebSocketOptions> webSocketConfiguration)
+            GraphSONWriter graphSONWriter, string mimeType, Action<ClientWebSocketOptions> webSocketConfiguration, ILogger logger = null)
         {
+            _logger = logger ?? NullLogger.Instance;
             _gremlinServer = gremlinServer;
             _mimeType = mimeType;
             _graphSONReader = graphSONReader ?? throw new ArgumentNullException(nameof(graphSONReader));
@@ -48,7 +52,7 @@ namespace Gremlin.Net.Driver
         public Connection CreateConnection()
         {
             return new Connection(_gremlinServer.Uri, _gremlinServer.Username, _gremlinServer.Password, _graphSONReader,
-                                 _graphSONWriter, _mimeType, _webSocketConfiguration);
+                                 _graphSONWriter, _mimeType, _webSocketConfiguration, _logger);
         }
     }
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPool.cs
@@ -35,90 +35,98 @@ namespace Gremlin.Net.Driver
     internal class ConnectionPool : IDisposable
     {
         private readonly ConnectionFactory _connectionFactory;
-        private readonly ConcurrentQueue<Connection> _connections = new ConcurrentQueue<Connection>();
+        private readonly List<Connection> _connections = new List<Connection>();
         private readonly int _poolSize;
         private readonly int _maxInProcessPerConnection;
-        private int _nrConnections;
-        private const int PoolEmpty = 0;
-        private const int PoolPopulationInProgress = -1;
+        private readonly EventAsync _availableConnection;
 
-        private SemaphoreSlim _populatePool;
+        private int _nrConnections;
+        private int scheduledConnection;
+    
+        private TimeSpan waitForConnectionTimeout = TimeSpan.FromMinutes(1);
+
+        // private const int PoolEmpty = 0;
+        // private const int PoolPopulationInProgress = -1;
+
+        // private SemaphoreSlim _populatePool;
 
         public ConnectionPool(ConnectionFactory connectionFactory, ConnectionPoolSettings settings)
         {
             _connectionFactory = connectionFactory;
             _poolSize = settings.PoolSize;
             _maxInProcessPerConnection = settings.MaxInProcessPerConnection;
-            _populatePool = new SemaphoreSlim(1, 1);
-            PopulatePoolAsync().WaitUnwrap();
+            _availableConnection = new EventAsync();
+            //_populatePool = new SemaphoreSlim(1, 1);
+            SchedulePopulatePool2(_poolSize);
         }
         
         public int NrConnections
         {
             get
             {
-                var nrConnections = Interlocked.CompareExchange(ref _nrConnections, PoolEmpty, PoolEmpty);
-                return nrConnections < 0 ? 0 : nrConnections;
+                return _nrConnections < 0 ? 0 : _nrConnections;
             }
         }
         
         public async Task<IConnection> GetAvailableConnectionAsync()
         {
-            await EnsurePoolIsPopulatedAsync().ConfigureAwait(false);
-            return ProxiedConnection(await GetConnectionFromPool());
+            // await EnsurePoolIsPopulatedAsync().ConfigureAwait(false);
+            //return ProxiedConnection(await GetConnectionFromPool());
+
+            return ProxiedConnection(await BorrowConnection());
         }
 
-        private async Task EnsurePoolIsPopulatedAsync()
-        {
-            Stopwatch watch = Stopwatch.StartNew();
-            // The pool could have been empty because of connection problems. So, we need to populate it again.
-            //  while (true)
-            //  {
-                // nrOpened = 1
-                // var nrOpened = Interlocked.CompareExchange(ref _nrConnections, PoolEmpty, PoolEmpty);
-                if (_nrConnections >= _poolSize) return;
-                int deficit = _poolSize - _nrConnections;
+        // private async Task EnsurePoolIsPopulatedAsync()
+        // {
+        //     Stopwatch watch = Stopwatch.StartNew();
+        //     // The pool could have been empty because of connection problems. So, we need to populate it again.
+        //     //  while (true)
+        //     //  {
+        //         // nrOpened = 1
+        //         // var nrOpened = Interlocked.CompareExchange(ref _nrConnections, PoolEmpty, PoolEmpty);
+        //         if (_nrConnections >= _poolSize) return;
+        //         int deficit = _poolSize - _nrConnections;
 
-                //ar curState = Interlocked.CompareExchange(ref _poolState, PoolInDeficit, PoolComplete);
-                //if (curState != PoolPopulationInProgress)
-                //{
-                    await PopulatePoolAsync().ConfigureAwait(false);
-                //}
-            // }
-            Console.WriteLine($"repopulated pool with deficit: {deficit}, duration: {watch.Elapsed.TotalMilliseconds}");
-        }
+        //         //ar curState = Interlocked.CompareExchange(ref _poolState, PoolInDeficit, PoolComplete);
+        //         //if (curState != PoolPopulationInProgress)
+        //         //{
+        //             await PopulatePoolAsync().ConfigureAwait(false);
+        //         //}
+        //     // }
+        //     Console.WriteLine($"repopulated pool with deficit: {deficit}, duration: {watch.Elapsed.TotalMilliseconds}");
+        // }
 
-        private async Task PopulatePoolAsync()
-        {
-            // var curState = Interlocked.CompareExchange(ref _poolState, PoolPopulationInProgress, PoolInDeficit);
-            // if (curState == PoolPopulationInProgress || _nrConnections >= _poolSize) return;
-            try
-            {
-                await _populatePool.WaitAsync().ConfigureAwait(false);
-                var _nrOpened = _nrConnections;
-                if (_nrOpened >= _poolSize) return;
+        // private async Task PopulatePoolAsync()
+        // {
+        //     // var curState = Interlocked.CompareExchange(ref _poolState, PoolPopulationInProgress, PoolInDeficit);
+        //     // if (curState == PoolPopulationInProgress || _nrConnections >= _poolSize) return;
+        //     try
+        //     {
+        //         await _populatePool.WaitAsync().ConfigureAwait(false);
+        //         var _nrOpened = _nrConnections;
+        //         if (_nrOpened >= _poolSize) return;
 
-                var poolDeficit = _poolSize - _nrOpened;
-                var connectionCreationTasks = new List<Task<Connection>>(poolDeficit);
-                for (var i = 0; i < poolDeficit; i++)
-                {
-                    connectionCreationTasks.Add(CreateNewConnectionAsync());
-                }
+        //         var poolDeficit = _poolSize - _nrOpened;
+        //         var connectionCreationTasks = new List<Task<Connection>>(poolDeficit);
+        //         for (var i = 0; i < poolDeficit; i++)
+        //         {
+        //             connectionCreationTasks.Add(CreateNewConnectionAsync());
+        //         }
 
-                var createdConnections = await Task.WhenAll(connectionCreationTasks).ConfigureAwait(false);
-                foreach (var c in createdConnections)
-                {
-                    _connections.Enqueue(c);
-                }
-            }
-            finally
-            {
-                // We need to remove the PoolPopulationInProgress flag again even if an exception occurred, so we don't block the pool population for ever
-                Console.WriteLine($"pool repopulated: {_connections.Count}");
-                Interlocked.Exchange(ref _nrConnections, _connections.Count);
-                _populatePool.Release();
-            }
-        }
+        //         var createdConnections = await Task.WhenAll(connectionCreationTasks).ConfigureAwait(false);
+        //         foreach (var c in createdConnections)
+        //         {
+        //             _connections.Enqueue(c);
+        //         }
+        //     }
+        //     finally
+        //     {
+        //         // We need to remove the PoolPopulationInProgress flag again even if an exception occurred, so we don't block the pool population for ever
+        //         Console.WriteLine($"pool repopulated: {_connections.Count}");
+        //         Interlocked.Exchange(ref _nrConnections, _connections.Count);
+        //         _populatePool.Release();
+        //     }
+        // }
         
         private async Task<Connection> CreateNewConnectionAsync()
         {
@@ -127,105 +135,316 @@ namespace Gremlin.Net.Driver
             return newConnection;
         }
 
-        private async Task<Connection> GetConnectionFromPool()
+        // private async Task<Connection> GetConnectionFromPool()
+        // {
+        //     Stopwatch watch = Stopwatch.StartNew();
+        //     while (true)
+        //     {
+        //         Stopwatch usedConnWatch = Stopwatch.StartNew();
+        //         var connection = await SelectLeastUsedConnection();
+        //         Console.WriteLine($"Selected coonncetion duration: {usedConnWatch.Elapsed.TotalMilliseconds}");
+        //         if (connection == null && _nrConnections > 0)
+        //         {
+        //             Console.WriteLine($"connections unavailable, retrying selction.");
+        //             continue;
+        //         }
+
+        //         if (connection == null)
+        //             throw new ServerUnavailableException();
+        //         if (connection.NrRequestsInFlight >= _maxInProcessPerConnection)
+        //             throw new ConnectionPoolBusyException(_poolSize, _maxInProcessPerConnection);
+        //         if (connection.IsOpen) {
+        //             _connections.Enqueue(connection);
+        //             Console.WriteLine($"Retrieved connection from pool. Duration: {watch.Elapsed.TotalMilliseconds}.");
+        //             return connection;
+        //         }
+
+        //         Console.WriteLine($"Bad connection.");
+        //         DefinitelyDestroyConnection(connection);
+        //     }
+        // }
+
+        private async Task<Connection> BorrowConnection()
         {
-            Stopwatch watch = Stopwatch.StartNew();
+            Connection leastUsedConn = SelectLeastUsedConnection2();
+
+            if (_connections.Count == 0)
+            {
+                // full re-population required.
+                SchedulePopulatePool2(_poolSize);
+                return await WaitForConnectionAsync(waitForConnectionTimeout);
+            }
+
+            if (leastUsedConn == null)
+            {
+                // We missed getting a connection after it was populated so wait for the next available.
+                // What if the pool is populated since? This won't get notified until a deficit is detected.
+                return await WaitForConnectionAsync(waitForConnectionTimeout);
+            }
+
+            int currentPoolSize = _connections.Count;
+            if (leastUsedConn.NrBorrowed >= _maxInProcessPerConnection && currentPoolSize < _poolSize)
+            {
+                // least used connection is too busy and the pool is not at capacity, schedule new connection.
+                ConsiderNewConnection();
+            }
+
+            // borrow the connection.
             while (true)
             {
-                Stopwatch usedConnWatch = Stopwatch.StartNew();
-                var connection = await SelectLeastUsedConnection();
-                Console.WriteLine($"Selected coonncetion duration: {usedConnWatch.Elapsed.TotalMilliseconds}");
-                if (connection == null && _nrConnections > 0)
+                int borrowed = leastUsedConn.NrBorrowed;
+                if (borrowed >= _maxInProcessPerConnection && leastUsedConn.NrRequestsInFlight >= _maxInProcessPerConnection)
                 {
-                    Console.WriteLine($"connections unavailable, retrying selction.");
-                    continue;
+                    return await WaitForConnectionAsync(waitForConnectionTimeout);
                 }
 
-                if (connection == null)
-                    throw new ServerUnavailableException();
-                if (connection.NrRequestsInFlight >= _maxInProcessPerConnection)
-                    throw new ConnectionPoolBusyException(_poolSize, _maxInProcessPerConnection);
-                if (connection.IsOpen) {
-                    _connections.Enqueue(connection);
-                    Console.WriteLine($"Retrieved connection from pool. Duration: {watch.Elapsed.TotalMilliseconds}.");
-                    return connection;
+                if (!leastUsedConn.IsOpen)
+                {
+                    ReplaceConnection(leastUsedConn);
+                    return await WaitForConnectionAsync(waitForConnectionTimeout);
                 }
 
-                Console.WriteLine($"Bad connection.");
-                DefinitelyDestroyConnection(connection);
+                if (leastUsedConn.TryCompareSetBorrow(borrowed, borrowed + 1))
+                {
+                    return leastUsedConn;
+                }
             }
         }
 
-        private async Task<Connection> SelectLeastUsedConnection()
+        private void SchedulePopulatePool2(int populateSize)
         {
-            if (_connections.IsEmpty) return null;
-            var nrMinInFlightConnections = int.MaxValue;
-            Connection leastBusy = null;
-            Stopwatch watch = Stopwatch.StartNew();
-            int repopulation = 0;
-            int poolContention = 0;
-            while (leastBusy == null)
+            populateSize = Math.Min(populateSize, _poolSize);
+            for (int i = 0; i < populateSize; ++i)
             {
-                int index = 0;
-                int nrAvaialable = _connections.Count;
-                while (index < nrAvaialable)
+                if (scheduledConnection < populateSize)
                 {
-                    if (!_connections.TryDequeue(out Connection connection))
-                    {
-                        break;
-                    }
+                    Interlocked.Increment(ref scheduledConnection);
+                    ScheduleNewConnection();
+                }
+            }
+        }
 
-                    if (connection.IsOpen)
+        private void ConsiderNewConnection()
+        {
+            while (true)
+            {
+                int inCreation = scheduledConnection;
+
+                if (inCreation >= 1)
+                {
+                    return;
+                }
+
+                if (Interlocked.CompareExchange(ref scheduledConnection, inCreation + 1, inCreation) == inCreation)
+                {
+                    break;
+                }
+            }
+
+            ScheduleNewConnection();
+        }
+
+        private void ScheduleNewConnection()
+        {
+            Task.Run(async () => {
+                await AddConnectionIfUnderMax();
+                Interlocked.Decrement(ref scheduledConnection);
+            }).Forget();
+        }
+
+        private async Task<Connection> WaitForConnectionAsync(TimeSpan timeout)
+        {
+            long start = Stopwatch.GetTimestamp();
+            TimeSpan remaining = timeout;
+
+            do
+            {
+                await _availableConnection.WaitAsync();
+
+                Connection leastUsedConn = SelectLeastUsedConnection2();
+                if (leastUsedConn != null) 
+                {
+                    while (true)
                     {
-                        var nrInFlight = connection.NrRequestsInFlight;
-                        if (nrInFlight >= nrMinInFlightConnections)
+                        int borrowed = leastUsedConn.NrBorrowed;
+                        if (borrowed >= _maxInProcessPerConnection)
                         {
-                            // found least used connection. Return last dequeued
-                            // conncection break-out.
-                            _connections.Enqueue(connection);
                             break;
                         }
 
-                        if (leastBusy != null)
+                        if (leastUsedConn.TryCompareSetBorrow(borrowed, borrowed + 1))
                         {
-                            // a less used connection was found. Return
-                            // previous candidate.
-                            _connections.Enqueue(leastBusy);
-                            leastBusy = null;
+                            return leastUsedConn;
                         }
+                    }
+                }
 
+                remaining = timeout - new TimeSpan(Stopwatch.GetTimestamp() - start);
+            }
+            while (remaining > TimeSpan.Zero);
+
+            ConsiderUnavailable();
+            throw new TimeoutException($"Timed out waiting for connection after {timeout}");
+        }
+
+        private Connection SelectLeastUsedConnection2()
+        {
+            var nrMinInFlightConnections = int.MaxValue;
+            var maxLastUsedTime = long.MinValue;
+            Connection leastBusy = null;
+
+            lock (_connections)
+            {
+                foreach (Connection connection in _connections)
+                {
+                    int nrInFlight = connection.NrRequestsInFlight;
+                    long lastUsed = connection.LastUsedTimeTicks;
+                    if (connection.IsOpen &&
+                        nrInFlight < nrMinInFlightConnections ||
+                        (nrInFlight == nrMinInFlightConnections &&
+                        maxLastUsedTime < lastUsed))
+                    {
                         nrMinInFlightConnections = nrInFlight;
+                        maxLastUsedTime = lastUsed;
                         leastBusy = connection;
                     }
-
-                    index++;
-                }
-
-                if (leastBusy == null)
-                {
-                    // If we didn't find a connection, the pool is either
-                    // seeing high contention (multiple threads trying to borrow a connection)
-                    // OR, the pool has reduced due to closed connections.
-                    if (NrConnections > 0)
-                    {
-                        poolContention++;
-                    }
-                    else
-                    {
-                        repopulation++;
-                        await EnsurePoolIsPopulatedAsync();
-                        nrAvaialable = _connections.Count;
-                    }
-                }
-                else
-                {
-                    _connections.Enqueue(leastBusy);
-                    Console.WriteLine($"Selected connection {index}. Repop: {repopulation}, Contention: {poolContention}, Duration; {watch.Elapsed.TotalMilliseconds}");
                 }
             }
 
             return leastBusy;
         }
+
+        private async Task<bool> AddConnectionIfUnderMax()
+        {
+            while (true)
+            {
+                int nrOpened = _nrConnections;
+                if (nrOpened >= _poolSize)
+                {
+                    return false;
+                }
+
+                if (Interlocked.CompareExchange(ref _nrConnections, nrOpened + 1, nrOpened) == nrOpened)
+                {
+                    break;
+                }
+            }
+
+            try
+            {
+                var connection = await CreateNewConnectionAsync();
+                lock (_connections)
+                {
+                    _connections.Add(connection);
+                }
+
+                _availableConnection.Notify();
+                return true;
+            }
+            catch
+            {
+                Interlocked.Decrement(ref _nrConnections);
+            }
+
+            return false;
+        }
+
+        private sealed class EventAsync
+        {
+            /// <summary>Task tracking pending waiters. Each pending waiter is waiting on this task.</summary>
+            /// <remarks>If null then there are no pending waiters.</remarks>
+            private TaskCompletionSource<object> task;
+
+            /// <summary>Waits for the event to be signaled.</summary>
+            /// <returns>Returns a task that completes when the event has been signaled.</returns>
+            public Task WaitAsync()
+            {
+                // If there are already pending waiters then just add to the list, otherwise create a new task.
+                TaskCompletionSource<object> newTaskCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                newTaskCompletionSource = Interlocked.CompareExchange(ref this.task, newTaskCompletionSource, null) ?? newTaskCompletionSource;
+                return newTaskCompletionSource.Task;
+            }
+
+            /// <summary>Pulses the event.</summary>
+            /// <remarks>All pending waiters are enabled, but subsequent waiters will block until the next signal.</remarks>
+            public void Notify()
+            {
+                // If there are no pending waiters then there is nothing to do.
+                TaskCompletionSource<object> oldTaskCompletionSource = Interlocked.Exchange(ref this.task, null);
+                oldTaskCompletionSource?.SetResult(null);
+            }
+        }
+
+        // private async Task<Connection> SelectLeastUsedConnection()
+        // {
+        //     if (_connections.IsEmpty) return null;
+        //     var nrMinInFlightConnections = int.MaxValue;
+        //     Connection leastBusy = null;
+        //     Stopwatch watch = Stopwatch.StartNew();
+        //     int repopulation = 0;
+        //     int poolContention = 0;
+        //     while (leastBusy == null)
+        //     {
+        //         int index = 0;
+        //         int nrAvaialable = _connections.Count;
+        //         while (index < nrAvaialable)
+        //         {
+        //             if (!_connections.TryDequeue(out Connection connection))
+        //             {
+        //                 break;
+        //             }
+
+        //             if (connection.IsOpen)
+        //             {
+        //                 var nrInFlight = connection.NrRequestsInFlight;
+        //                 if (nrInFlight >= nrMinInFlightConnections)
+        //                 {
+        //                     // found least used connection. Return last dequeued
+        //                     // conncection break-out.
+        //                     _connections.Enqueue(connection);
+        //                     break;
+        //                 }
+
+        //                 if (leastBusy != null)
+        //                 {
+        //                     // a less used connection was found. Return
+        //                     // previous candidate.
+        //                     _connections.Enqueue(leastBusy);
+        //                     leastBusy = null;
+        //                 }
+
+        //                 nrMinInFlightConnections = nrInFlight;
+        //                 leastBusy = connection;
+        //             }
+
+        //             index++;
+        //         }
+
+        //         if (leastBusy == null)
+        //         {
+        //             // If we didn't find a connection, the pool is either
+        //             // seeing high contention (multiple threads trying to borrow a connection)
+        //             // OR, the pool has reduced due to closed connections.
+        //             if (NrConnections > 0)
+        //             {
+        //                 poolContention++;
+        //             }
+        //             else
+        //             {
+        //                 repopulation++;
+        //                 await EnsurePoolIsPopulatedAsync();
+        //                 nrAvaialable = _connections.Count;
+        //             }
+        //         }
+        //         else
+        //         {
+        //             _connections.Enqueue(leastBusy);
+        //             Console.WriteLine($"Selected connection {index}. Repop: {repopulation}, Contention: {poolContention}, Duration; {watch.Elapsed.TotalMilliseconds}");
+        //         }
+        //     }
+
+        //     return leastBusy;
+        // }
         
         private IConnection ProxiedConnection(Connection connection)
         {
@@ -234,8 +453,13 @@ namespace Gremlin.Net.Driver
 
         private void ReturnConnectionIfOpen(Connection connection)
         {
-            if (connection.IsOpen) return;
-            ConsiderUnavailable();
+            if (connection.IsOpen)
+            {
+                _availableConnection.Notify();
+                return;
+            }
+
+            ReplaceConnection(connection);
         }
 
         private void ConsiderUnavailable()
@@ -243,19 +467,57 @@ namespace Gremlin.Net.Driver
             CloseAndRemoveAllConnectionsAsync().WaitUnwrap();
         }
 
+        private async void ReplaceConnection(Connection connection)
+        {
+            try
+            {
+                if (connection.IsOpen)
+                {
+                    await connection.CloseAsync().ConfigureAwait(false);
+                }
+
+                DefinitelyDestroyConnection(connection);
+            }
+            finally
+            { 
+                lock (_connections)
+                {
+                    _connections.Remove(connection);
+                }
+            }
+
+            ConsiderNewConnection();
+        }
+
         private async Task CloseAndRemoveAllConnectionsAsync()
         {
-            while (_connections.TryDequeue(out var connection))
+            List<Connection> connectionsToDestroy = new List<Connection>();
+            lock (_connections)
             {
-                await connection.CloseAsync().ConfigureAwait(false);
-                DefinitelyDestroyConnection(connection);
+                for (int i = 0; i < _connections.Count; ++i)
+                {
+                    connectionsToDestroy.Add(_connections[i]);
+                    _connections.RemoveAt(i);
+                }
+            }
+
+            foreach (var connection in connectionsToDestroy)
+            {
+                try
+                {
+                    await connection.CloseAsync().ConfigureAwait(false);
+                    DefinitelyDestroyConnection(connection);
+                }
+                catch
+                {
+                    // Ignore exceptions here.
+                }
             }
         }
 
         private void DefinitelyDestroyConnection(Connection connection)
         {
             connection.Dispose();
-            // remove from pool
             Interlocked.Decrement(ref _nrConnections);
         }
 

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPoolSettings.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/ConnectionPoolSettings.cs
@@ -33,8 +33,13 @@ namespace Gremlin.Net.Driver
     {
         private int _poolSize = DefaultPoolSize;
         private int _maxInProcessPerConnection = DefaultMaxInProcessPerConnection;
+        private int _maxSimultaneousUsagePerConnection = DefaultMaxInProcessPerConnection;
+        private TimeSpan _maxWaitForConnection = TimeSpan.FromSeconds(DefaultMaxWaitForConnectionInSeconds);
+        private TimeSpan _reconnectInterval = TimeSpan.FromSeconds(DefaultReconnectIntervalInMilliseconds);
         private const int DefaultPoolSize = 4;
         private const int DefaultMaxInProcessPerConnection = 32;
+        private const int DefaultMaxWaitForConnectionInSeconds = 60;
+        private const int  DefaultReconnectIntervalInMilliseconds = 100;
 
         /// <summary>
         ///     Gets or sets the size of the connection pool.
@@ -69,6 +74,55 @@ namespace Gremlin.Net.Driver
                     throw new ArgumentOutOfRangeException(nameof(MaxInProcessPerConnection),
                         "MaxInProcessPerConnection must be > 0!");
                 _maxInProcessPerConnection = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets the maximum number of times a connection can be borrowed from the pool simultaneously.
+        /// </summary>
+        /// <remarks>
+        ///     The default value is 32. A <see cref="NoConnectionAvailableException" /> is thrown if this limit is reached on
+        ///     all connections when a new request comes in.
+        /// </remarks>
+        public int MaxSimultaneousUsagePerConnection
+        {
+            get => _maxSimultaneousUsagePerConnection;
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentOutOfRangeException(nameof(MaxSimultaneousUsagePerConnection),
+                        "Must be > 0!");
+                _maxSimultaneousUsagePerConnection = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets the amount of time in milliseconds to wait for a new connection before timing out.
+        /// </summary>
+        public TimeSpan MaxWaitForConnection
+        {
+            get => _maxWaitForConnection;
+            set
+            {
+                if (value < TimeSpan.Zero)
+                    throw new ArgumentOutOfRangeException(nameof(MaxWaitForConnection),
+                        "Must be >= 0!");
+                _maxWaitForConnection = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets the amount of time in milliseconds to wait before trying to reconnect to a dead endpoint.
+        /// </summary>
+        public TimeSpan ReconnectInterval
+        {
+            get => _reconnectInterval;
+            set
+            {
+                if (_reconnectInterval < TimeSpan.Zero)
+                    throw new ArgumentOutOfRangeException(nameof(ReconnectInterval),
+                        "Must be >= 0!");
+                _reconnectInterval = value;
             }
         }
     }

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/CloseConnectionException.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/CloseConnectionException.cs
@@ -1,0 +1,62 @@
+#region License
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using System;
+using System.Net.WebSockets;
+
+namespace Gremlin.Net.Driver.Exceptions
+{
+    /// <summary>
+    ///     The exception that is thrown when a websocket close message is received from Gremlin Server.
+    /// </summary>
+    public class CloseConnectionException : Exception
+    {
+        /// <summary>
+        /// Initialize a new instance of <see cref="CloseConnectionException" /> class.
+        /// </summary>
+        /// <param name="id">The id of the connection that closed.</param>
+        /// <param name="closeStatus">The status of the close message returned by the server.</param>
+        /// <param name="closeDescription">The close description returned by the server</param>
+        public CloseConnectionException(Guid id, WebSocketCloseStatus? closeStatus, string closeDescription)
+        {
+            CloseStatus = closeStatus;
+            CloseDescription = closeDescription;
+            ConnectionId = id;
+        }
+
+        /// <summary>
+        /// Gets the status of the close message returned.
+        /// </summary>
+        public WebSocketCloseStatus? CloseStatus { get; }
+
+        /// <summary>
+        /// Gets close description returned by the server.
+        /// </summary>
+        public string CloseDescription { get; }
+
+        /// <summary>
+        /// Gets the id of the connection which was closed.
+        /// </summary>
+        public Guid ConnectionId { get; }
+    }
+}

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ConnectionPoolBusyException.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/Exceptions/ConnectionPoolBusyException.cs
@@ -42,16 +42,17 @@ namespace Gremlin.Net.Driver.Exceptions
         /// <summary>
         ///     Initializes a new instance of the <see cref="ConnectionPoolBusyException" /> class.
         /// </summary>
-        public ConnectionPoolBusyException(int poolSize, int maxInProcessPerConnection)
-            : base(CreateMessage(poolSize, maxInProcessPerConnection))
+        public ConnectionPoolBusyException(int poolSize, int maxInProcessPerConnection, string message)
+            : base(CreateMessage(poolSize, maxInProcessPerConnection, message))
         {
             PoolSize = poolSize;
             MaxInProcessPerConnection = maxInProcessPerConnection;
         }
 
-        private static string CreateMessage(int poolSize, int maxInProcessPerConnection)
+        private static string CreateMessage(int poolSize, int maxInProcessPerConnection, string message)
         {
-            return $"All {poolSize} connections have reached their " +
+            string additionalMessage = message + " ";
+            return $"{message}All {poolSize} connections have reached their " +
                    $"{nameof(ConnectionPoolSettings.MaxInProcessPerConnection)} limit of {maxInProcessPerConnection}." +
                    $" Consider increasing either the {nameof(ConnectionPoolSettings.PoolSize)} or the " +
                    $"{nameof(ConnectionPoolSettings.MaxInProcessPerConnection)} limit.";

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs
@@ -27,6 +27,8 @@ using System.Net.WebSockets;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Structure.IO.GraphSON;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Gremlin.Net.Driver
 {
@@ -46,6 +48,7 @@ namespace Gremlin.Net.Driver
         public const string GraphSON2MimeType = "application/vnd.gremlin-v2.0+json";
         
         private readonly ConnectionPool _connectionPool;
+        private readonly ILogger _logger;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="GremlinClient" /> class for the specified Gremlin Server.
@@ -59,17 +62,20 @@ namespace Gremlin.Net.Driver
         ///     A delegate that will be invoked with the <see cref="ClientWebSocketOptions" />
         ///     object used to configure WebSocket connections.
         /// </param>
+        /// <param name="logger">An instance of logger.</param>
         public GremlinClient(GremlinServer gremlinServer, GraphSONReader graphSONReader = null,
             GraphSONWriter graphSONWriter = null, string mimeType = null,
             ConnectionPoolSettings connectionPoolSettings = null,
-            Action<ClientWebSocketOptions> webSocketConfiguration = null)
+            Action<ClientWebSocketOptions> webSocketConfiguration = null,
+            ILogger logger = null)
         {
+            _logger = logger ?? NullLogger.Instance;
             var reader = graphSONReader ?? new GraphSON3Reader();
             var writer = graphSONWriter ?? new GraphSON3Writer();
             var connectionFactory = new ConnectionFactory(gremlinServer, reader, writer, mimeType ?? DefaultMimeType,
-                webSocketConfiguration);
+                webSocketConfiguration, _logger);
             _connectionPool =
-                new ConnectionPool(connectionFactory, connectionPoolSettings ?? new ConnectionPoolSettings());            
+                new ConnectionPool(connectionFactory, connectionPoolSettings ?? new ConnectionPoolSettings(), _logger);
         }
 
         /// <summary>

--- a/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinServer.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinServer.cs
@@ -22,6 +22,8 @@
 #endregion
 
 using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Gremlin.Net.Driver
 {

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -25,7 +25,7 @@ limitations under the License.
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
-    <Version>3.4.1-SNAPSHOT-A2</Version>
+    <Version>3.4.1-SNAPSHOT-A4</Version>
     <FileVersion>3.4.1.0</FileVersion>
     <AssemblyVersion>3.4.0.0</AssemblyVersion>
     <Title>Gremlin.Net</Title>

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -25,7 +25,7 @@ limitations under the License.
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
-    <Version>3.4.1-SNAPSHOT-A1</Version>
+    <Version>3.4.1-SNAPSHOT-A2</Version>
     <FileVersion>3.4.1.0</FileVersion>
     <AssemblyVersion>3.4.0.0</AssemblyVersion>
     <Title>Gremlin.Net</Title>

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -25,7 +25,7 @@ limitations under the License.
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
-    <Version>3.4.1-SNAPSHOT</Version>
+    <Version>3.4.1-SNAPSHOT-A1</Version>
     <FileVersion>3.4.1.0</FileVersion>
     <AssemblyVersion>3.4.0.0</AssemblyVersion>
     <Title>Gremlin.Net</Title>

--- a/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
+++ b/gremlin-dotnet/src/Gremlin.Net/Gremlin.Net.csproj
@@ -25,7 +25,7 @@ limitations under the License.
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
-    <Version>3.4.1-SNAPSHOT-A4</Version>
+    <Version>3.4.1-SNAPSHOT-pool-alpha-1</Version>
     <FileVersion>3.4.1.0</FileVersion>
     <AssemblyVersion>3.4.0.0</AssemblyVersion>
     <Title>Gremlin.Net</Title>
@@ -56,12 +56,16 @@ NOTE that versions suffixed with "-rc" are considered release candidates (i.e. p
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging">
+      <Version>1.1.2</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes to Gremlin.NET connection pool to enable the following:
- Select connections based on least used, then based on last activity, to ensure that activity is shared across the pool (important for Cosmos DB Gremlin API where connections will be timed if there is no request activity).
- Avoid racing request from selecting the same connection.
- Schedule creating new connection when capacity is available. This will done when connection could not be selected from the pool, and can remove a dead connection in order to make room for a new connection.
- Allow requests to wait for a connection to become available if the pool is busy/connections are being created. These will get timed based on a setting.
- If dead connection when it is returned by a request, create a replacement connection.
- Only consider the pool closed/service unavailable if the pool is unable to reconnect for some timeout.

### Testing:
Stress testing with highly concurrent request workload. This was done by:

- At intervals fire concurrent requests on the client. For each iteration, increase the number of concurrent requests by a factor.
- Testing with low frequency such that connections would be idled out by the server.
- Testing manually closing connections outside of the workload application (simulating random connectivity issue).
- High load/concurrency where requests are continuously firing.
